### PR TITLE
Update to Gehn 20 and Detect Unsupported OSes

### DIFF
--- a/Installer.nsi
+++ b/Installer.nsi
@@ -5,6 +5,7 @@
 ; Includes ;
 ;;;;;;;;;;;;
 !include MUI2.nsh
+!include WinVer.nsh
 
 ;;;;;;;;;;;;;;;;;;;;;;
 ; Installer Settings ;
@@ -48,6 +49,21 @@ Var LaunchRepair
 ;;;;;;;;;;;;;
 ; Functions ;
 ;;;;;;;;;;;;;
+
+; Inform the user if their OS is unsupported.
+Function .onInit
+  ${IfNot} ${AtLeastWinVista}
+    MessageBox MB_YESNO|MB_ICONEXCLAMATION \
+       "Windows Vista or above is required to run Gehn Shard.$\r$\n\
+        You may install the client but will be unable to run it on this OS.$\r$\n$\r$\n\
+        Do you still wish to install?" \
+        /SD IDYES IDNO do_quit
+  ${EndIf}
+  Goto done
+  do_quit:
+    Quit
+  done:
+FunctionEnd
 
 ; Tries to find the Uru Live directory in the registry.
 Function FindUruDir


### PR DESCRIPTION
Adds a check which warns the user if they'll be unable to run the Gehn Shard client.
